### PR TITLE
Add coverage from .ts files extensions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts(x)'],
+  collectCoverageFrom: ['src/**/*.ts(x)?'],
   setupFilesAfterEnv: ['<rootDir>/.jest/setup.ts']
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts(x)?'],
+  collectCoverageFrom: ['src/**/*.ts(x)?', '!src/**/stories.tsx'],
   setupFilesAfterEnv: ['<rootDir>/.jest/setup.ts']
 }


### PR DESCRIPTION
O regex para verificar o coverage dos arquivos levava em consideração apenas arquivos com extensão tsx:
`'src/**/*.ts(x)'`

![image](https://user-images.githubusercontent.com/41276009/86306858-aea55180-bbeb-11ea-8d9a-3cf635059662.png)


Foi alterado para fazer a coleta de coverage tanto de arquivos com extensão tsx como arquivos ts:
`'src/**/*.ts(x)?'`

![image](https://user-images.githubusercontent.com/41276009/86306917-d4caf180-bbeb-11ea-80a7-03e1f3741a31.png)
