### PR TITLE
chore(lint): not ignore jest and storybook config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+!.storybook
+!.jest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+!.storybook
+!.jest


### PR DESCRIPTION
As default, the folders and files named starting with dot is ignored by the Eslint and Prettier. Nows we overwrite this behavior to include theses folder into lint process.

Here are some reference links:

https://github.com/eslint/eslint/issues/10341
https://github.com/eslint/eslint/blob/master/docs/user-guide/configuring.md#eslintignore
https://github.com/storybookjs/storybook/issues/295