### PR TITLE
Update jest config to recognize absolute imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts(x)?', '!src/**/stories.tsx'],
-  setupFilesAfterEnv: ['<rootDir>/.jest/setup.ts']
+  setupFilesAfterEnv: ['<rootDir>/.jest/setup.ts'],
+  modulePaths: ['<rootDir>/src/']
 }


### PR DESCRIPTION
Hi there :wave: 

I decided to use this boilerplate to bootstrap a project I'm working on. I realized an error is thrown If I run a test that renders a component and the component uses an absolute import:
![image](https://user-images.githubusercontent.com/12154623/88464728-79f78380-ce93-11ea-92e1-98f8afb8d54d.png)

In order to solve the problem, the [modulePaths](https://jestjs.io/docs/en/next/configuration#modulepaths-arraystring) option can be used to set additional locations to search when resolving modules. So we can set this option to search for the `src` folder, since the absolute imports are using it as the base folder. 
