### PR TITLE
[fix] Styled components style rule test

### DIFF
--- a/src/components/Main/test.tsx
+++ b/src/components/Main/test.tsx
@@ -16,6 +16,6 @@ describe('<Main />', () => {
   it('should render the colors correctly', () => {
     const { container } = render(<Main />)
 
-    expect(container.firstChild).toHaveStyleRule('background-color', '#06092b');
+    expect(container.firstChild).toHaveStyleRule('background-color', '#06092b')
   })
 })

--- a/src/components/Main/test.tsx
+++ b/src/components/Main/test.tsx
@@ -16,6 +16,6 @@ describe('<Main />', () => {
   it('should render the colors correctly', () => {
     const { container } = render(<Main />)
 
-    expect(container.firstChild).toHaveStyle({ 'background-color': '#06092b' })
+    expect(container.firstChild).toHaveStyleRule('background-color', '#06092b');
   })
 })


### PR DESCRIPTION
Hey guys!

Updating Styled Components  to ^5.2.0 breaks the `toHaveStyle` assertion (you can see it on #93). 
`jest-styled-components` docs ~~recommend using `toHaveStyleRule` now~~ use `toHaveStyleRule` on their examples.

See ya! 👋