### PR TITLE
Atualizando dependências mais mantendo a compatibilidade.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
     ]
   },
   "dependencies": {
-    "next": "10.0.0",
+    "next": "^10.0.0",
     "next-pwa": "^3.1.5",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
-    "styled-components": "5.2.1"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "styled-components": "^5.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/preset-typescript": "^7.12.1",
-    "@storybook/addon-essentials": "6.0.28",
-    "@storybook/react": "6.0.28",
+    "@storybook/addon-essentials": "^6.0.28",
+    "@storybook/react": "^6.0.28",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.0",
     "@types/jest": "^26.0.15",


### PR DESCRIPTION
As versões de alguns pacotes estavam exatas(1.23.5) então adicionei "^"(^1.23.5) para atualizar somente as versões `MINOR` e `PATCH`, mantendo a compatibilidade como descrito [aqui](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#dependencies).

As dependências alteradas foram:
next
react
react-dom
styled-components
@storybook/addon-essentials
@storybook/react