### PR TITLE
ci: Add cache to yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 14.x
       
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: yarn-cache
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
+      
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: |
+            ~/cache
+            !~/cache/exclude
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
Eu estou tentando adicionar [cache](https://github.com/actions/cache) ao `nodemodule`  e `~/.cache` para acelerar a action

Entretanto ao testar encontrei o seguinte problema e pensei em abrir o pull request para outras pessoas poderem ajudar,
Rodando ele pela segunda vez  (com uma alteração em um titulo) ele fala que não encontrou o cache:
![Cache not found for input keys: Linux-yarn-0dceeb](https://user-images.githubusercontent.com/32439070/107080683-6200a500-67d0-11eb-98fa-297ed566f29c.png)

Mas no final na parte de subir o cache ele fala que ele já existe:
![Cache already exists. Scope: refs/pull/6/merge, Key: Linux-yarn-0dceeb](https://user-images.githubusercontent.com/32439070/107080847-92e0da00-67d0-11eb-8273-caf66a8847fa.png)

Conferi os hashs gerados e eles também batem, pela documentação do repositorio e do [github](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key) parece estar tudo

