### PR TITLE
bug fix storybook-static

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ module.exports = {
   addons: ['@storybook/addon-essentials'],
   babel: async (options) => ({
     ...options,
-    plugins: [...options.plugins, '@babel/plugin-transform-react-jsx']
+    plugins: [...options.plugins,  require.resolve('@babel/plugin-transform-react-jsx')]
   }),
   webpackFinal: (config) => {
     config.resolve.modules.push(`${process.cwd()}/src`)


### PR DESCRIPTION
Como expliquei nos comentários da aula 29.
O aquivo  .storybook/main.js , na configuração do babel, vocês devem, ao final do array plugins, subistituir '@babel/plugin-transform-react-jsx' por  require.resolve('@babel/plugin-transform-react-jsx') , conforme fiz no meu [aqui](https://github.com/rodrigocode4/react-avancado/blob/f0d95b7f6c0308235171f49e210f0fb0f1bf9f9e/.storybook/main.js#L7) e a [documentação](https://storybook.js.org/docs/react/addons/writing-presets#babel)

Mas, por quê?

Bom, primeiro fui investigar com um console.log - destacado em amarelo -, rodei o comando yarn build-storybook - [com configurações  do package.json](https://github.com/rodrigocode4/react-avancado/blob/f0d95b7f6c0308235171f49e210f0fb0f1bf9f9e/package.json#L13) - o que eram os valores do array plugins do aquivo .storybook/main.js confome o print:

<img src="https://pbs.twimg.com/media/Ev0yko6XYAI7DoN?format=jpg&name=medium" alt="Imagem com código de bug de path do plugin do babel, destacado em cores">

Percerem que os elementos do array plugins - destacado em azul - são vários paths de plugins e que o último elemento - destacado em vermelho - é apenas uma string ? daí a necessidade do utrilizar  require.resolve('@babel/plugin-transform-react-jsx'), que pega o caminho relativo e faz um join com o argumento passado.

Obs-01: No live-server não funciona porque ele só serve um único arquivo. Por isso recomendo o [http-server](https://www.npmjs.com/package/http-server) como servidor para testar os aquivos da pasta storybook-static

Obs-02: Às pessoas em que o bug não acontece, é porque provavelmente com as atualizações da lib, eles "corrigiram esse erro".

Abraço