### PR TITLE
Add missing "theme-color" meta tag.

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,7 @@ function App({ Component, pageProps }: AppProps) {
         <link rel="shortcut icon" href="/img/icon-512.png" />
         <link rel="apple-touch-icon" href="/img/icon-512.png" />
         <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#06092B" />
         <meta
           name="description"
           content="A simple project starter to work with TypeScript, React, NextJS and Styled Components"


### PR DESCRIPTION
:lipstick: No vídeo "Configurando PWA" o arquivo `src/pages_app.tsx` tem uma tag `meta` com `name="theme-color"` como neste PR.