### PR TITLE
Add next eslint plugin to existing config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
     "plugin:react/recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:@next/next/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "next:lint": "next lint",
     "lint": "eslint src --max-warnings=0",
     "test": "jest --maxWorkers=50%",
     "test:watch": "jest --watch --maxWorkers=25%",


### PR DESCRIPTION
### Description
Just noticed it is possible to extend the Next plugin for ESlint to the [existing configuration](https://nextjs.org/docs/basic-features/eslint#migrating-existing-config). This way the `yarn lint` with custom configuration  will have the new next rules. (Would this mean that the next:lint script at package.json is not longer neccesary?) I tested it here, and is working with the ESLint extension for VSCode.