### PR TITLE
move prettier rules into eslint file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,14 @@
     "react-hooks/exhaustive-deps": "warn",
     "react/prop-types": "off",
     "react/react-in-jsx-scope": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off"
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "prettier/prettier": [
+      "warn",
+      {
+        "semi": false,
+        "singleQuote": true,
+        "trailingComma": "none"
+      }
+    ]
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-!.storybook
-!.jest

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}


### PR DESCRIPTION
This PR moves the Prettier rules into the ESLint configuration file.

Included are:

* Rules moved to `.estlintrc.json` file.
* Delete `.prettierignore` and `.prettierrc` files.